### PR TITLE
Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ logs
 results
 npm-debug.log
 node_modules
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ node_js:
 
 # Use faster Docker architecture on Travis.
 sudo: false
+
+script: "npm test && npm run coveralls"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Throttle the parallelism of an asynchronous, promise returning, function / functions.  This has special utility when you set the concurrency to `1`.  That way you get a mutually exclusive lock.
 
 [![Build Status](https://img.shields.io/travis/ForbesLindesay/throat/master.svg)](https://travis-ci.org/ForbesLindesay/throat)
+[![Coverage Status](https://img.shields.io/coveralls/ForbesLindesay/throat/master.svg?style=flat)](https://coveralls.io/r/ForbesLindesay/throat?branch=master)
 [![Dependency Status](https://img.shields.io/gemnasium/ForbesLindesay/throat.svg)](https://gemnasium.com/ForbesLindesay/throat)
 [![NPM version](https://img.shields.io/npm/v/throat.svg)](http://badge.fury.io/js/throat)
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Throttle the parallelism of an asynchronous, promise returning, function / funct
 [![Dependency Status](https://img.shields.io/gemnasium/ForbesLindesay/throat.svg)](https://gemnasium.com/ForbesLindesay/throat)
 [![NPM version](https://img.shields.io/npm/v/throat.svg)](http://badge.fury.io/js/throat)
 
+[![Sauce Test Status](https://saucelabs.com/browser-matrix/throat.svg)](https://saucelabs.com/u/throat)
+
 ## Installation
 
     npm install throat

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",
     "promise": "^6.1.0",
+    "sauce-test": "^1.0.0",
+    "test-result": "^2.0.0",
     "testit": "^2.0.2"
   },
   "scripts": {
-    "test": "node test/index.js",
+    "test": "node test/index.js && node test/browser.js",
     "coverage": "istanbul cover test/index.js",
     "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -13,11 +13,15 @@
   ],
   "dependencies": {},
   "devDependencies": {
+    "coveralls": "^2.11.2",
+    "istanbul": "^0.3.5",
     "promise": "^6.1.0",
     "testit": "^2.0.2"
   },
   "scripts": {
-    "test": "node test/index.js"
+    "test": "node test/index.js",
+    "coverage": "istanbul cover test/index.js",
+    "coveralls": "npm run coverage && cat ./coverage/lcov.info | coveralls"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,11 @@
   ],
   "dependencies": {},
   "devDependencies": {
-    "mocha": "*",
     "promise": "^6.1.0",
     "testit": "^2.0.2"
   },
   "scripts": {
-    "test": "mocha -R spec"
+    "test": "node test/index.js"
   },
   "repository": {
     "type": "git",

--- a/test/browser.js
+++ b/test/browser.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var run = require('sauce-test');
+var testResult = require('test-result');
+
+var LOCAL = !process.env.CI && process.argv[2] !== 'sauce';
+var USER = 'throat';
+var ACCESS_KEY = '57db1bf4-537a-4bde-ab8b-1e82eed9db4b';
+
+if (process.env.CI && process.version.indexOf('v0.12.') !== 0) {
+  // only run the browser tests once
+  process.exit(0);
+}
+run(__dirname + '/index.js', LOCAL ? 'chromedriver' : 'saucelabs', {
+  username: USER,
+  accessKey: ACCESS_KEY,
+  browserify: true,
+  disableSSL: true,
+  filterPlatforms: function (platform, defaultFilter) {
+    // exclude some arbitrary browsers to make tests
+    // run faster.  Also excludes beta versions of browsers
+    if (!defaultFilter(platform)) return false;
+    // these platforms don't support ES5
+    var version = +platform.version;
+    switch (platform.browserName) {
+      case 'internet explorer':
+        return version > 8;
+      case 'firefox':
+        return version > 4;
+      case 'iphone':
+      case 'ipad':
+        return version > 5.1;
+      default:
+        return true;
+    }
+  },
+  bail: true,
+  timeout: '30s'
+}).done(function (result) {
+  if (result.passed) {
+    testResult.pass('browser tests');
+  } else {
+    testResult.fail('browser tests');
+  }
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var test = require('testit');
 var Promise = require('promise');
 var throat = require('../')(Promise);
 
@@ -45,8 +46,8 @@ function worker(max) {
   return execute
 }
 
-describe('throat(n)', function () {
-  it('throat(1) acts as a lock', function (done) {
+test('throat(n)', function () {
+  test('throat(1) acts as a lock', function (done) {
     var lock = throat(1)
     var a = job(), b = job(), c = job();
     var resA = lock(a)
@@ -81,7 +82,7 @@ describe('throat(n)', function () {
     })
     .nodeify(done)
   })
-  it('throat(2) lets two processes acquire the same lock', function (done) {
+  test('throat(2) lets two processes acquire the same lock', function (done) {
     var lock = throat(2)
     var a = job(), b = job(), c = job();
     var resA = lock(a)
@@ -116,7 +117,7 @@ describe('throat(n)', function () {
     })
     .nodeify(done)
   })
-  it('throat(3) lets three processes acquire the same lock', function (done) {
+  test('throat(3) lets three processes acquire the same lock', function (done) {
     var lock = throat(3)
     var a = job(), b = job(), c = job();
     var resA = lock(a)
@@ -154,8 +155,8 @@ describe('throat(n)', function () {
 })
 
 
-describe('throat(n, fn)', function () {
-  it('throat(1, fn) acts as a sequential worker', function (done) {
+test('throat(n, fn)', function () {
+  test('throat(1, fn) acts as a sequential worker', function (done) {
     Promise.all([sentA, sentB, sentC].map(throat(1, worker(1))))
       .then(function (res) {
         assert(res[0] instanceof Processed && res[0].val.length > 1 && res[0].val[0] === sentA)
@@ -164,7 +165,7 @@ describe('throat(n, fn)', function () {
       })
       .nodeify(done)
   })
-  it('throat(2, fn) works on two inputs in parallel', function (done) {
+  test('throat(2, fn) works on two inputs in parallel', function (done) {
     Promise.all([sentA, sentB, sentC].map(throat(2, worker(2))))
       .then(function (res) {
         assert(res[0] instanceof Processed && res[0].val.length > 1 && res[0].val[0] === sentA)
@@ -173,7 +174,7 @@ describe('throat(n, fn)', function () {
       })
       .nodeify(done)
   })
-  it('throat(3, fn) works on three inputs in parallel', function (done) {
+  test('throat(3, fn) works on three inputs in parallel', function (done) {
     Promise.all([sentA, sentB, sentC].map(throat(3, worker(3))))
       .then(function (res) {
         assert(res[0] instanceof Processed && res[0].val.length > 1 && res[0].val[0] === sentA)


### PR DESCRIPTION
This makes the following changes:

 - swap mocha for [testit](https://github.com/ForbesLindesay/testit) so that tests are simply run via `node test/index.js`
 - Add code coverage using istanbul and coveralls - this is really simple having switched from mocha to testit
 - Add sauce labs integration - because [sauce-test](https://github.com/ForbesLindesay/sauce-test) has built in support for testit, this is incredibly easy.