### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "parallelism",
     "limit"
   ],
+  "files": ["index.js"],
   "dependencies": {},
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
Prevents `test` and `.travis.yml` from being published to NPM.