### PR TITLE
Use an efficient queue implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
+var Deque = require('double-ended-queue');
+
 module.exports = function (PromiseArgument) {
   var Promise;
   function throat(size, fn) {
-    var queue = [];
+    var queue = new Deque();
     function run(fn, self, args) {
       if (size) {
         size--;
@@ -20,7 +22,7 @@ module.exports = function (PromiseArgument) {
     }
     function release() {
       size++;
-      if (queue.length) {
+      if (!queue.isEmpty()) {
         var next = queue.shift();
         next.resolve(run(next.fn, next.self, next.args));
       }

--- a/index.js
+++ b/index.js
@@ -3,26 +3,26 @@
 module.exports = function (PromiseArgument) {
   var Promise;
   function throat(size, fn) {
-    var queue = []
+    var queue = [];
     function run(fn, self, args) {
       if (size) {
-        size--
+        size--;
         var result = new Promise(function (resolve) {
-          resolve(fn.apply(self, args))
-        })
-        result.then(release, release)
-        return result
+          resolve(fn.apply(self, args));
+        });
+        result.then(release, release);
+        return result;
       } else {
         return new Promise(function (resolve) {
-          queue.push(new Delayed(resolve, fn, self, args))
-        })
+          queue.push(new Delayed(resolve, fn, self, args));
+        });
       }
     }
     function release() {
-      size++
+      size++;
       if (queue.length) {
-        var next = queue.shift()
-        next.resolve(run(next.fn, next.self, next.args))
+        var next = queue.shift();
+        next.resolve(run(next.fn, next.self, next.args));
       }
     }
     if (typeof size === 'function') {
@@ -83,8 +83,8 @@ if (typeof Promise === 'function') {
 }
 
 function Delayed(resolve, fn, self, args) {
-  this.resolve = resolve
-  this.fn = fn
-  this.self = self || null
-  this.args = args
+  this.resolve = resolve;
+  this.fn = fn;
+  this.self = self || null;
+  this.args = args;
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "parallelism",
     "limit"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "double-ended-queue": "^2.1.0-0"
+  },
   "devDependencies": {
     "coveralls": "^2.11.2",
     "istanbul": "^0.4.5",

--- a/perf.js
+++ b/perf.js
@@ -1,0 +1,15 @@
+const throat = require('./index');
+
+const promises = [];
+for (let i = 0; i < 1000000; i++) {
+  promises.push(() => new Promise(resolve => process.nextTick(resolve)));
+}
+
+Promise.resolve().then(async () => {
+  for (let amount = 10; amount <= 1000000; amount = amount * 10) {
+    const list = promises.slice(0, amount);
+    console.time(amount + ' promises');
+    await Promise.all(list.map(throat(10, fn => fn())));
+    console.timeEnd(amount + ' promises');
+  }
+});


### PR DESCRIPTION
I'm dealing with 100,000 to 1 million promises. Don't blame me, blame async/await. I noticed poor runtime performance of my code and thought it was because of what I was doing in the promises but after profiling performance about 95% of the time in my program was spent removing the first item from large arrays. This makes sense: in v8, this operation is linear but appears fast for small arrays because of some trickery.

This diff:
* Introduces a performance benchmark that works in node 7+ (requires async/await). I don't think it makes much sense to support older versions of node for this one.
* Swaps out the array queue with [`double-ended-queue`](https://yarnpkg.com/en/package/double-ended-queue).

Before:
```
[cpojer ~/P/throat (master|ahead)]$ node perf.js
10 promises: 1.709ms
100 promises: 5.487ms
1000 promises: 17.602ms
10000 promises: 218.416ms
100000 promises: 8287.715ms
node(16363,0x7fffe04c03c0) malloc: *** error for object 0xc0000000: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
fish: 'node perf.js' terminated by signal SIGABRT (Abort)
```

I don't know how long it actually took until node crashed because I went to the kitchen to chop some vegetables. I think it was about 15 minutes.

After:
```
10 promises: 1.619ms
100 promises: 5.351ms
1000 promises: 13.490ms
10000 promises: 182.118ms
100000 promises: 1143.396ms
1000000 promises: 15271.319ms
```

Starting at 1000 promises, this yields a real performance boost of about 40ms. At 100,000 promises, we are looking at a 7x faster runtime and at 1 million promises the current implementation crashes node while the new one finishes in about 15 seconds.

The tests still pass but I'm not sure if you'd like me to write any new tests as part of this change.