### PR TITLE
Replace double-ended-queue with denque

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
-'use strict'
+'use strict';
 
-var Deque = require('double-ended-queue');
+var Denque = require('denque');
 
 module.exports = function (PromiseArgument) {
   var Promise;
   function throat(size, fn) {
-    var queue = new Deque();
+    var queue = new Denque();
     function run(fn, self, args) {
       if (size) {
         size--;
@@ -49,7 +49,7 @@ module.exports = function (PromiseArgument) {
           args.push(arguments[i]);
         }
         return run(fn, this, args);
-      }
+      };
     } else {
       return function (fn) {
         if (typeof fn !== 'function') {
@@ -62,7 +62,7 @@ module.exports = function (PromiseArgument) {
           args.push(arguments[i]);
         }
         return run(fn, this, args);
-      }
+      };
     }
   }
   if (arguments.length === 1 && typeof PromiseArgument === 'function') {
@@ -77,7 +77,7 @@ module.exports = function (PromiseArgument) {
     }
     return throat(arguments[0], arguments[1]);
   }
-}
+};
 
 /* istanbul ignore next */
 if (typeof Promise === 'function') {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "limit"
   ],
   "dependencies": {
-    "double-ended-queue": "^2.1.0-0"
+    "denque": "^1.1.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
`denque` is slightly faster than `double-ended-queue`.

Before:

```
$ node perf.js 
10 promises: 3.303ms
100 promises: 1.804ms
1000 promises: 10.349ms
10000 promises: 209.485ms
100000 promises: 1103.597ms
1000000 promises: 21267.233ms
```

After:

```
$ node perf.js 
10 promises: 2.259ms
100 promises: 1.194ms
1000 promises: 8.490ms
10000 promises: 196.285ms
100000 promises: 1080.001ms
1000000 promises: 19734.413ms
```