### PR TITLE
Add comment explaining how to use the typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,4 +2,4 @@ declare function throat<TResult, TFn extends (...args: Array<any>) => Promise<TR
 declare function throat<TResult, TFn extends (...args: Array<any>) => Promise<TResult>>(fn: TFn, size: number): TFn;
 declare function throat(size: number): <TResult>(fn: () => Promise<TResult>) => Promise<TResult>;
 
-export = throat;
+export = throat; // get typings via: import throat = require("throat")


### PR DESCRIPTION
Various other common patterns either produce syntax errors or fail to work as expected, such as:

* `const throat = require('throat');`
* `import * as throat from 'throat';`
* `import {throat} from 'throat';`